### PR TITLE
Fix hardcoded score threshold.

### DIFF
--- a/mods/King of the Hill/modules/config.lua
+++ b/mods/King of the Hill/modules/config.lua
@@ -189,7 +189,7 @@ function Initialise(ScenarioInfo)
     config.hillUnit = InterpretUnit(config.kingOfTheHillHillUnit)
     config.penaltyController, config.penaltyAlly = InterpretPenalty(config.kingOfTheHillHillPenalty)
 
-    config.scoreAccThreshold = 20
+    config.scoreAccThreshold = config.hillPoints
     config.scoreSeqThreshold = 8
 
     -- attempt to override with map specific settings


### PR DESCRIPTION
Previously this would always be '20' points and the Lobby configuration option was ignored