### PR TITLE
Add more options

### DIFF
--- a/mods/King of the Hill - TSR/lua/AI/LobbyOptions/lobbyoptions.lua
+++ b/mods/King of the Hill - TSR/lua/AI/LobbyOptions/lobbyoptions.lua
@@ -46,12 +46,17 @@ AIOpts =
     },
 
     {
-		default 	= 2,
+		default 	= 3,
 		label 		= "Koth-TSR: Delay",
 		help 		= "Defines how long it takes for the hill to become active.",
 		key 		= 'KingOfTheHillHillDelay',
 		pref	 	= 'KingOfTheHillHillDelay',
 		values 		= {
+            { 
+                text = "No Delay", 
+                help = "The hill will be active at start.", 
+                key = -1, 
+            },
 			{ 
                 text = "Four minutes", 
                 help = "The hill will be active after four minutes.", 
@@ -70,7 +75,12 @@ AIOpts =
             { 
                 text = "Ten minutes", 
                 help = "The hill will be active after ten minutes.", 
-                key = 3, 
+                key = 4, 
+            },
+            { 
+                text = "Twenty minutes", 
+                help = "The hill will be active after twenty minutes.", 
+                key = 9, 
             },
 		},	
     },
@@ -107,6 +117,11 @@ AIOpts =
 		key 		= 'KingOfTheHillHillScore',
 		pref	 	= 'KingOfTheHillHillScore',
 		values 		= {
+            { 
+                text = "20", 
+                help = "The first team with a player of 20 points will win.", 
+                key = 0, 
+            },	
 			{ 
                 text = "30", 
                 help = "The first team with a player of 30 points will win. Good for short matches.", 
@@ -131,6 +146,11 @@ AIOpts =
                 text = "70", 
                 help = "The first team with a player of 70 points will win. Good for long matches.", 
                 key = 5, 
+            },
+            { 
+                text = "80", 
+                help = "The first team with a player of 80 points will win.", 
+                key = 6, 
             },
 		},	
     },
@@ -171,12 +191,22 @@ AIOpts =
     },
 
     {
-		default 	= 1,
+		default 	= 3,
 		label 		= "Koth-TSR: Tech introduction delay",
 		help 		= "Defines how long it takes for all the other players to have their tech restrictions lifted.",
 		key 		= 'KingOfTheHillHillTechIntroductionDelay',
 		pref	 	= 'KingOfTheHillHillTechIntroductionDelay',
 		values 		= {
+            { 
+                text = "No Delay", 
+                help = "All the other players will have the latest tech restrictions lifted at the same time.", 
+                key = -1, 
+            },	
+            { 
+                text = "One minute", 
+                help = "After one minute all the other players will have the latest tech restrictions lifted.", 
+                key = 0, 
+            },	
 			{ 
                 text = "Two minutes", 
                 help = "After two minutes all the other players will have the latest tech restrictions lifted.", 
@@ -202,6 +232,11 @@ AIOpts =
 		key 		= 'KingOfTheHillHillPenalty',
 		pref	 	= 'KingOfTheHillHillPenalty',
 		values 		= {
+            { 
+                text = "No Penalty", 
+                help = "No mass production penalty.", 
+                key = -1, 
+            },	
 			{ 
                 text = "20 and 10 percent", 
                 help = "The controller will have a 20 percent mass production penalty, its team members will have a 10 percent mass production penalty.", 
@@ -221,21 +256,31 @@ AIOpts =
     },
 
     {
-		default 	= 1,
+		default 	= 3,
 		label 		= "Koth-TSR: Tech unlock curve",
 		help 		= "Defines how many points you need to unlock an additional tech.",
 		key 		= 'KingOfTheHillTechCurve',
 		pref	 	= 'KingOfTheHillTechCurve',
 		values 		= {
+            { 
+                text = "No Tech restrictions", 
+                help = "All Tech unlocked from the start.", 
+                key = 1, 
+            },	
+            { 
+                text = "Tech 2 Start", 
+                help = "Tech 2 will be unlocked at start, tech 3 at 20 percent of the total points and experimentals at 40 percent of the total points.", 
+                key = 2, 
+            },	
 			{ 
                 text = "Early", 
                 help = "Tech 2 will be unlocked at 20 percent of the total points, tech 3 at 40 percent of the total points and experimentals at 60 percent of the total points.", 
-                key = 1, 
+                key = 3, 
             },	
 			{ 
                 text = "Averaged", 
                 help = "Tech 2 will be unlocked at 30 percent of the total points, tech 3 at 55 percent of the total points and experimentals at 80 percent of the total points.", 
-                key = 2, 
+                key = 4, 
             },	
 		},	
     },

--- a/mods/King of the Hill - TSR/modules/config.lua
+++ b/mods/King of the Hill - TSR/modules/config.lua
@@ -1,6 +1,7 @@
 
-local configs = import("/mods/King Of The Hill/modules/map-specifics.lua").configs
-local options = import("/mods/King Of The Hill/mod_options.lua").options
+local path = "King of the Hill - TSR";
+local configs = import("/mods/" .. path .. "/modules/map-specifics.lua").configs
+local options = import("/mods/" .. path .. "/mod_options.lua").options
 
 function Initialise(ScenarioInfo)
 
@@ -99,6 +100,8 @@ function Initialise(ScenarioInfo)
     function InterpretTechCurve(kingOfTheHillTechCurve)
 
         local values = {
+            { 0.0, 0.0, 0.0 },
+            { 0.0, 0.2, 0.4 },
             { 0.2, 0.4, 0.6 },
             { 0.3, 0.55, 0.8 }
         }
@@ -131,7 +134,7 @@ function Initialise(ScenarioInfo)
     end
 
     function InterpretDelay(kingOfTheHillHillDelay)
-        return 5 --120 + 120 * kingOfTheHillHillDelay 
+        return 120 + 120 * kingOfTheHillHillDelay 
     end
 
     function InterpretCenter(kingOfTheHillHillCenter)
@@ -158,7 +161,7 @@ function Initialise(ScenarioInfo)
     end
 
     function InterpretScore(kingOfTheHillHillScore)
-        return 10 + 10 * kingOfTheHillHillScore
+        return 20 + 10 * kingOfTheHillHillScore
     end
 
     function InterpretUnit(kingOfTheHillHillUnit)
@@ -177,6 +180,7 @@ function Initialise(ScenarioInfo)
 
     -- interpret the options set manually
     config.hillActiveAt = InterpretDelay(config.kingOfTheHillHillDelay)
+
     config.hillCenter = InterpretCenter(config.kingOfTheHillHillCenter)
     config.hillRadius = InterpretSize(config.kingOfTheHillHillSize)
     config.techIntroductionDelay = InterpretTechDelay(config.kingOfTheHillHillTechIntroductionDelay)
@@ -185,6 +189,11 @@ function Initialise(ScenarioInfo)
     config.restrictionsT2LiftedAt = math.floor(config.techCurveT2 * config.hillPoints)
     config.restrictionsT3LiftedAt = math.floor(config.techCurveT3 * config.hillPoints)
     config.restrictionsT4LiftedAt = math.floor(config.techCurveT4 * config.hillPoints)
+
+    -- set the starting restrictions based on the lifted at values
+    config.restrictedT2 = config.restrictionsT2LiftedAt > 0
+    config.restrictedT3 = config.restrictionsT3LiftedAt > 0 
+    config.restrictedT4 = config.restrictionsT4LiftedAt > 0  
 
     config.hillUnit = InterpretUnit(config.kingOfTheHillHillUnit)
     config.penaltyController, config.penaltyAlly = InterpretPenalty(config.kingOfTheHillHillPenalty)

--- a/mods/King of the Hill - TSR/modules/controllerUI.lua
+++ b/mods/King of the Hill - TSR/modules/controllerUI.lua
@@ -85,6 +85,12 @@ function ProcessPlayerPointData(playerTables)
             army.iconContesting:SetHidden(not player.isContesting and not player.isDefeated)
         end
 
+        if interface.config then
+            if interface.config.hillActiveAt > GetGameTimeSeconds() then
+                interface.box.textContesting:SetText(string.format("Can contest in %i", interface.config.hillActiveAt - GetGameTimeSeconds() ))
+            end
+        end
+        
         -- show defeated armies in grey
         if player.isDefeated then
             army.nickname:SetColor('ff999999');

--- a/mods/King of the Hill - TSR/modules/sim-tick.lua
+++ b/mods/King of the Hill - TSR/modules/sim-tick.lua
@@ -84,7 +84,16 @@ function KingOfTheHillThread()
         ScenarioFramework.CreateVisibleAreaLocation(config.hillRadius * 1.1, config.hillCenter, 0, brain)
     end
 
-    WaitSeconds(config.hillActiveAt)
+    -- WaitSeconds(config.hillActiveAt)
+
+    -- wait until the hill is active
+    while config.hillActiveAt < GetGameTimeSeconds() do 
+        WaitSeconds(0.1)
+
+        --Update UI
+        Sync.SendPlayerPointData = playerTable
+    end
+
 
     -- start the clock
     local count = 0


### PR DESCRIPTION
-Fixed config.lua referencing old King of the Hill mod
-Update UI while hill is not active with countdown
-Added 'No Delay' and 'One minute' options to other player restrictions lifted delay
-Fixed Hill Delay not used.
-Added 'No Delay' and 'Twenty minutes' options.
-Added more total hill score options
-Added 'No Penalty' Mass penalty option
-Added 'No Tech restrictions' and 'Tech 2 Start' Tech unlock options