### PR TITLE
Bugfix option 'Center of all spawned players' 

### DIFF
--- a/mods/King of the Hill - TSR/mod_options.lua
+++ b/mods/King of the Hill - TSR/mod_options.lua
@@ -105,9 +105,14 @@ options =
                 key = 2, 
             },	
 			{ 
-                text = "Center of all spawned players", 
-                help = "The hill will be located at the average position of all spawned players.", 
+                text = "Center of all spawned players (excluding AI)", 
+                help = "The hill will be located at the average position of all spawned human players.", 
                 key = 3, 
+            },
+			{ 
+                text = "Center of all spawned players (including AI)", 
+                help = "The hill will be located at the average position of all spawned human or AI players.", 
+                key = 4, 
             },
 		},	
     },

--- a/mods/King of the Hill - TSR/modules/config.lua
+++ b/mods/King of the Hill - TSR/modules/config.lua
@@ -3,6 +3,7 @@ import("/mods/king of the hill - tsr/modules/constants.lua")
 
 local configs = import("/mods/" .. kothConstants.path .. "/modules/map-specifics.lua").configs
 local options = import("/mods/" .. kothConstants.path .. "/mod_options.lua").options
+local simUtils = import("/mods/" .. kothConstants.path .. "/modules/sim-utils.lua")
 
 function Initialise(ScenarioInfo)
 
@@ -154,7 +155,11 @@ function Initialise(ScenarioInfo)
         end
 
         if kingOfTheHillHillCenter == 3 then 
-            center = ComputeMiddleOfPlayers()
+            center = ComputeMiddleOfPlayers(false)
+        end
+
+        if kingOfTheHillHillCenter == 4 then 
+            center = ComputeMiddleOfPlayers(true)
         end
 
         -- LOG(repr(center))
@@ -246,12 +251,13 @@ function ComputeMiddleOfTheMap()
 end
 
 --- Computes the center of the start locations of all present players.
-function ComputeMiddleOfPlayers()
+-- @param includeAI boolean that indicates whether to treat AI as players
+function ComputeMiddleOfPlayers(includeAI)
     local total = { 0, 0 }
 
-    -- go over all the applicable brains
-    local state, brains = FindPlayersSim()
-    for _, brain in brains do 
+    -- go over all the applicable theBrains
+    local theBrains = simUtils.GetActiveBrains(includeAI)
+    for _, brain in theBrains do 
         -- keep track on their position to compute the average
         local x, z = brain:GetArmyStartPos()
         total[1] = total[1] + x
@@ -259,7 +265,7 @@ function ComputeMiddleOfPlayers()
     end
 
     -- compute the average
-    local count = table.getn(brains)
+    local count = table.getn(theBrains)
     local center = { total[1] / count, 0, total[2] / count }
     center[2] = GetSurfaceHeight(center[1], center[3])
     

--- a/mods/King of the Hill - TSR/modules/sim-utils.lua
+++ b/mods/King of the Hill - TSR/modules/sim-utils.lua
@@ -1,4 +1,6 @@
 
+-- is this necessary for ArmyBrains?
+-- local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
 local ScenarioFramework = import('/lua/ScenarioFramework.lua')
 
 --- Sends an announcement to all the players.
@@ -31,3 +33,16 @@ function SendAnnouncementWithVoice(title, subtitle, delay, bank, cue)
         true
     );
 end
+
+--- Filters all the brains available to ensure only brains
+-- that are controlled by humans are returned
+function GetActiveBrains(includeAI)
+    local humanBrains = { }
+    for k, brain in ArmyBrains do 
+        LOG("Found Brain: k=" .. k .. " . BrainType: " .. brain.BrainType)
+        if includeAI or not (brain.BrainType == "AI") then
+            table.insert(humanBrains, brain)
+        end
+    end 
+    return humanBrains
+end   


### PR DESCRIPTION
This was previously calling a function that did not exist 'FindPlayersSim'
* Our bugfix implements an equivalent function in sim-utils.lua to return active brains (including or excluding AI) in the scenario.

Add an extra center of hill option, so we can choose to also include AIs in our center point calculation
* The "including AI" option for center of all spawned players is mostly useless, as AI are not treated as KoTH players anyway, but it was useful to include for testing and can't hurt adding it as an option.