### PR TITLE
Fix up announcement text - show a useful message on the screen rather than the mod name.

### DIFF
--- a/mods/King of the Hill - TSR/modules/controllerUI.lua
+++ b/mods/King of the Hill - TSR/modules/controllerUI.lua
@@ -167,7 +167,7 @@ function ProcessConfig(data)
     -- change the corresponding pieces of text
     interface.box.text1:SetText('One point is given for every ' .. data.ticks)
 	
-	interface.box.restrictions4:SetText('Experimental tech: after ' .. data.restrictionsT4LiftedAt .. ' points')
-	interface.box.restrictions3:SetText('Tech 3: after ' .. data.restrictionsT3LiftedAt .. ' points')
-	interface.box.restrictions2:SetText('Tech 2: after ' .. data.restrictionsT2LiftedAt .. ' points')
+    interface.box.restrictions4:SetText('Experimental tech: after ' .. data.restrictionsT4LiftedAt .. ' points')
+    interface.box.restrictions3:SetText('Tech 3: after ' .. data.restrictionsT3LiftedAt .. ' points')
+    interface.box.restrictions2:SetText('Tech 2: after ' .. data.restrictionsT2LiftedAt .. ' points')
 end

--- a/mods/King of the Hill - TSR/modules/sim-restrictions.lua
+++ b/mods/King of the Hill - TSR/modules/sim-restrictions.lua
@@ -140,7 +140,7 @@ function Tick(config, playerTables)
                 );
 
                 simUtils.SendAnnouncementWithVoice(
-                    kothConstants.modName,
+                    "Tech 2 is available to all players.",
                     "Tech 2 is available to all players.",
                     config.techIntroductionDelay,
                     "KingOfTheHill",
@@ -174,7 +174,7 @@ function Tick(config, playerTables)
                 );
 
                 simUtils.SendAnnouncementWithVoice(
-                    kothConstants.modName,
+                    "Tech 3 is available to all players.",
                     "Tech 3 is available to all players.",
                     config.techIntroductionDelay,
                     "KingOfTheHill",
@@ -208,7 +208,7 @@ function Tick(config, playerTables)
                 );
 
                 simUtils.SendAnnouncementWithVoice(
-                    kothConstants.modName,
+                    "Experimental tech is available to all players.",
                     "Experimental tech is available to all players.",
                     config.techIntroductionDelay,
                     "KingOfTheHill",

--- a/mods/King of the Hill - TSR/modules/sim-tick.lua
+++ b/mods/King of the Hill - TSR/modules/sim-tick.lua
@@ -59,24 +59,32 @@ function KingOfTheHillThread()
         end
     );
 
-    simUtils.SendAnnouncementWithVoice(
-        kothConstants.modName,                                                 -- title
-        "The hill is activated in " .. config.hillActiveAt .. " seconds.",  -- subtitle
-        10,                                                                 -- delay
-        "KingOfTheHill",                                                    -- bank
-        "King"                                                              -- cue
-    );
+    if config.hillActiveAt > 0 then
+        simUtils.SendAnnouncementWithVoice(
+          "The hill activates in " .. config.hillActiveAt .. " seconds.",     -- title
+          "The hill is activated in " .. config.hillActiveAt .. " seconds.",  -- subtitle
+          10,                                                                 -- delay
+          "KingOfTheHill",                                                    -- bank
+          "King"                                                              -- cue
+        );
+    end
 
-    simUtils.SendAnnouncement(
-        kothConstants.modName,
-        "The hill is activated in " .. math.floor(0.5 * config.hillActiveAt) .. " seconds.",
-        math.floor(0.5 * config.hillActiveAt)
-    );
+    if config.hillActiveAt > 0 then
+        simUtils.SendAnnouncement(
+            "The hill activates in " .. math.floor(0.5 * config.hillActiveAt) .. " seconds.",
+            "The hill is activated in " .. math.floor(0.5 * config.hillActiveAt) .. " seconds.",
+            math.floor(0.5 * config.hillActiveAt)
+        );
+    end
 
+    local hillActiveMessageDelay = 0
+    if config.hillActiveAt > 0 then
+      hillActiveMessageDelay = 2
+    end
     simUtils.SendAnnouncementWithVoice(
-        kothConstants.modName,
+        "The hill is now active.",
         "The hill is active.",
-        config.hillActiveAt - 2,
+        config.hillActiveAt - hillActiveMessageDelay,
         "KingOfTheHill",
         "Hill-Active" 
     );


### PR DESCRIPTION
Show the actual announcement message on the screen rather than the mod name.

Also, introduce a small edge case fix for the announcement of a team taking the lead - this would previously not work when we had a single human player in the game.

Minor formatting fixes for controllerUI (tabs to spaces)