### PR TITLE
Fix issue #12 - hill active state was being ignored and points could be earned before hill was active.

### DIFF
--- a/mods/King of the Hill - TSR/modules/sim-hill.lua
+++ b/mods/King of the Hill - TSR/modules/sim-hill.lua
@@ -7,6 +7,10 @@ function Tick(config, thresholds, brains)
     return processed, analysed
 end
 
+function isHillActive(config)
+    return GetGameTimeSeconds() > config.hillActiveAt
+end
+
 --- Computes the amount of mass, number of units and whether there is a 
 -- commander on the hill for each provided brain.
 -- @param config The configuration of the mod.
@@ -67,13 +71,18 @@ function AnalyseHill(config, analyses, thresholds)
 
     -- we assume the hill is abandoned.
     local state = { }
-    state.active = true
+    state.active = isHillActive(config)
     state.controlled = false
     state.contested = false
     state.commanderOnHill = false
     state.identifier = 0
     state.conquerers = { }
     state.contestants = { }
+
+    -- If hill is not yet active, then do not analyse the hill.
+    if not (state.active) then
+        return state
+    end
 
     -- determine if there is a commander on the hill
     for k, analysis in analyses do 

--- a/mods/King of the Hill - TSR/modules/sim-tick.lua
+++ b/mods/King of the Hill - TSR/modules/sim-tick.lua
@@ -93,17 +93,9 @@ function KingOfTheHillThread()
     for k, brain in ArmyBrains do 
         ScenarioFramework.CreateVisibleAreaLocation(config.hillRadius * 1.1, config.hillCenter, 0, brain)
     end
-
-    -- WaitSeconds(config.hillActiveAt)
-
-    -- wait until the hill is active
-    while config.hillActiveAt < GetGameTimeSeconds() do 
-        WaitSeconds(0.1)
-
-        --Update UI
-        Sync.SendPlayerPointData = playerTable
-    end
-
+    
+    --Update UI
+    Sync.SendPlayerPointData = playerTable
 
     -- start the clock
     local count = 0
@@ -113,7 +105,6 @@ function KingOfTheHillThread()
 
         count = count + 1 
         if count > 10 then  
-
             -- routines called every 10th tick
 
             -- update information
@@ -183,17 +174,6 @@ function InitialisePlayerTables(brains)
 
     return playerTables
 end 
-
---- Initialises a default hill table.
-function InitialiseHillTable()
-    local hillTable = { } 
-    hillTable.active=false
-    hillTable.commanderOnHill=false
-    hillTable.contested=false
-    hillTable.controlled=false
-    hillTable.identifier=0
-    return hillTable 
-end
 
 --- Filters all the brains available to ensure only brains 
 -- controlled by humans remain.


### PR DESCRIPTION
sim-tick:
* Get rid of bad comparison logic in while wait loop for inactive hill (loop was never fired when a hill active delay was selected)

sim-hill / AnalyseHill fixes:
* Change analyseHill function in sim-hill, set hill active state based on comparison between config.hillActiveAt and GetGameTimeSeconds().
* Exit analyseHill early if active state is false, meaning that controlled state will never get set, resulting in no points being allocated.

These changes allow the UI dialog to be updated with information (e.g. commander on hill / mass on hill) but points won't be allocated until hill is active.