### PR TITLE
Feature/commander hill control option

### DIFF
--- a/mods/King of the Hill - TSR/mod_options.lua
+++ b/mods/King of the Hill - TSR/mod_options.lua
@@ -300,7 +300,7 @@ options =
                 pref            = 'tsrKothCommanderControlHill',
                 values          = {
             {
-                text = "Yes (default)",
+                text = "Yes",
                 help = "If a commander is present on the hill, it overrides the need for the mass threshold to control or contest the hill.",
                 key = 1,
             },

--- a/mods/King of the Hill - TSR/mod_options.lua
+++ b/mods/King of the Hill - TSR/mod_options.lua
@@ -291,4 +291,25 @@ options =
             },	
 		},	
     },
+
+    {
+                default         = 1,
+                label           = kothConstants.lobbyLabelPrefix .. ": Commander can control hill",
+                help            = "A commander immediately contests or controls a hill, if present on the hill.",
+                key             = 'tsrKothCommanderControlHill',
+                pref            = 'tsrKothCommanderControlHill',
+                values          = {
+            {
+                text = "Yes (default)",
+                help = "If a commander is present on the hill, it overrides the need for the mass threshold to control or contest the hill.",
+                key = 1,
+            },
+            {
+                text = "No",
+                help = "A commander does not override the mass threshold for hill control and is not counted towards controlling or contesting the hill.",
+                key = 2,
+            },
+        },
+    },
+
 }

--- a/mods/King of the Hill - TSR/modules/config.lua
+++ b/mods/King of the Hill - TSR/modules/config.lua
@@ -67,6 +67,9 @@ function Initialise(ScenarioInfo)
         -- 2 = center of all spawns
         -- 3 = center of all players
         config.hillCenter = { 0, 0, 0 }
+
+        -- commanders can control and contest the hill on their own
+        config.kingOfTheHillCommanderControl = 1
     end
 
     local function DefaultRawValues(config)
@@ -80,6 +83,7 @@ function Initialise(ScenarioInfo)
         config.kingOfTheHillHillUnit = FindDefaultOption(options, "tsrKothHillUnit")
         config.kingOfTheHillHillPenalty = FindDefaultOption(options, "tsrKothHillPenalty")
         config.kingOfTheHillHillTechIntroductionDelay = FindDefaultOption(options, "tsrKothHillTechIntroductionDelay")
+        config.kingOfTheHillCommanderControl = FindDefaultOption(options, "tsrKothCommanderControlHill")
     end
 
     DefaultValues(config)
@@ -97,6 +101,7 @@ function Initialise(ScenarioInfo)
         config.kingOfTheHillHillUnit = ScenarioInfo.Options.tsrKothHillUnit or config.kingOfTheHillHillUnit
         config.kingOfTheHillHillPenalty = ScenarioInfo.Options.tsrKothHillPenalty or config.kingOfTheHillHillPenalty
         config.kingOfTheHillHillTechIntroductionDelay = ScenarioInfo.Options.tsrKothHillTechIntroductionDelay or config.kingOfTheHillHillTechIntroductionDelay
+        config.kingOfTheHillCommanderControl = ScenarioInfo.Options.tsrKothCommanderControlHill or config.kingOfTheHillCommanderControl
     end
 
     function InterpretTechCurve(kingOfTheHillTechCurve)
@@ -136,7 +141,7 @@ function Initialise(ScenarioInfo)
     end
 
     function InterpretDelay(kingOfTheHillHillDelay)
-        return 120 + 120 * kingOfTheHillHillDelay 
+        return 120 + (120 * kingOfTheHillHillDelay)
     end
 
     function InterpretCenter(kingOfTheHillHillCenter)
@@ -181,7 +186,11 @@ function Initialise(ScenarioInfo)
     end
 
     function InterpretTechDelay(kingOfTheHillHillDelay)
-        return 60 + 60 * kingOfTheHillHillDelay 
+        return 60 + (60 * kingOfTheHillHillDelay)
+    end
+    
+    function InterpretCommanderCanControl(kingOfTheHillCommanderControl)
+        return 1 == kingOfTheHillCommanderControl
     end
 
     -- interpret the options set manually
@@ -195,6 +204,8 @@ function Initialise(ScenarioInfo)
     config.restrictionsT2LiftedAt = math.floor(config.techCurveT2 * config.hillPoints)
     config.restrictionsT3LiftedAt = math.floor(config.techCurveT3 * config.hillPoints)
     config.restrictionsT4LiftedAt = math.floor(config.techCurveT4 * config.hillPoints)
+
+    config.kingOfTheHillCommanderControl = InterpretCommanderCanControl(config.kingOfTheHillCommanderControl)
 
     -- set the starting restrictions based on the lifted at values
     config.restrictedT2 = config.restrictionsT2LiftedAt > 0

--- a/mods/King of the Hill - TSR/modules/sim-hill.lua
+++ b/mods/King of the Hill - TSR/modules/sim-hill.lua
@@ -7,6 +7,10 @@ function Tick(config, thresholds, brains)
     return processed, analysed
 end
 
+function canCommanderControlHill(config, commanderOnHill)
+   return (config.kingOfTheHillCommanderControl and commanderOnHill)
+end
+
 --- Computes the amount of mass, number of units and whether there is a 
 -- commander on the hill for each provided brain.
 -- @param config The configuration of the mod.
@@ -84,13 +88,13 @@ function AnalyseHill(config, analyses, thresholds)
     conquerers = { }
     contestants = { }
     for k, analysis in analyses do 
-        canControl = analysis.massOnHill >= thresholds.control or analysis.commanderOnHill
+        canControl = analysis.massOnHill >= thresholds.control or canCommanderControlHill(config, analysis.commanderOnHill)
         if canControl then 
             table.insert(conquerers, analysis)
             table.insert(state.conquerers, analysis.identifier )
         end
 
-        canContest = analysis.massOnHill >= thresholds.contest or analysis.commanderOnHill
+        canContest = analysis.massOnHill >= thresholds.contest or canCommanderControlHill(config, analysis.commanderOnHill)
         if canContest then
             table.insert(contestants, analysis)
             table.insert(state.contestants, analysis.identifier )
@@ -122,7 +126,7 @@ function AnalyseHill(config, analyses, thresholds)
     -- daym, so many hostile commanders on that hill
     if commanderContested then 
         state.controlled = false
-        state.contested = true
+        state.contested = canCommanderControlHill(config, true)
         state.identifier = 0
         return state
     end
@@ -132,7 +136,7 @@ function AnalyseHill(config, analyses, thresholds)
     if commanderCount == 1 then 
         -- only take conquerers with commanders
         for k, player in conquerers do 
-            if player.commanderOnHill then 
+            if canCommanderControlHill(config, player.commanderOnHill) then 
                 controller = player 
             end
         end
@@ -142,7 +146,7 @@ function AnalyseHill(config, analyses, thresholds)
     local potentials = { }
     if commanderCount > 1 and not controller then
         for k, player in conquerers do 
-            if player.commanderOnHill then 
+            if canCommanderControlHill(config, player.commanderOnHill) then 
                 table.insert(potentials, player)
             end
         end


### PR DESCRIPTION
A toggle that sets whether a commander will count towards contest or control of a hill.

By default the KoTH mod would ignore the mass requirement for a commander and immediately contest or control a hill. 

With the introduction of this lobby option you can now turn off the commander from doing this.

We could potentially add another option that makes the commander count towards some 'mass' amount as well.